### PR TITLE
Updated dashboards scripts to insert/replace correct datasource UID

### DIFF
--- a/scripts/assets/common/grafana_client.py
+++ b/scripts/assets/common/grafana_client.py
@@ -279,6 +279,14 @@ class GrafanaClient:
         
         return existing_alerts, True
     
+    def _get_datasource_uid_map(self):
+        """Fetch all datasources and return a map of name (lowercase) to UID."""
+        datasources, success = self._http_get_request_to_grafana("/api/datasources")
+        if not success:
+            log.error("Failed to fetch datasources from Grafana")
+            return {}
+        return {ds["name"].lower(): ds["uid"] for ds in datasources if "name" in ds and "uid" in ds}
+    
     def upload_dashboard(self, dashboard_data, folder_name):
         """Uploads a single dashboard to the specified Grafana folder."""
         created, folder_id = self._create_alert_folder_if_not_exists(folder_name)


### PR DESCRIPTION
Update the script to add Datasource UID in the Dashboard Panels (top level + targets)

- If UID is empty -> will have the `kfusedatasource` uid value filled in
- If UID has `${DS_KFUSEDATASOURCE}` -> It will pickup the `KFUSEDATASOURCE` string part use that to find what uid to replace

Tested on Pisco
Was able to import dashboards with these UID formats without issues.