### PR TITLE
fix batch delete bug.

### DIFF
--- a/scripts/deleteSegmentsByTableAndWhereClause.py
+++ b/scripts/deleteSegmentsByTableAndWhereClause.py
@@ -6,7 +6,7 @@ import requests
 import sys
 from typing import List, Dict, Any, Set, Tuple
 
-def make_request(url: str, method: str = 'GET', json_data: Dict = None, params: Dict = None, timeout: int = 5) -> requests.Response:
+def make_request(url: str, method: str = 'GET', json_data: Dict = None, params: Dict = None, timeout: int = 5, debug: bool = False) -> requests.Response:
     """Make HTTP request with error handling"""
     try:
         if method == 'GET':
@@ -14,6 +14,9 @@ def make_request(url: str, method: str = 'GET', json_data: Dict = None, params: 
         elif method == 'POST':
             response = requests.post(url, json=json_data, timeout=timeout)
         elif method == 'DELETE':
+            if debug:
+                print(f"Making DELETE request to: {url}")
+                print(f"Query parameters: {json.dumps(params, indent=2)}")
             response = requests.delete(url, params=params, timeout=timeout)
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
@@ -87,16 +90,17 @@ def delete_segments_for_type(args, table_name: str, table_type: str, segments: L
     """Delete segments for a specific table type"""
     print(f"\n  Processing {table_type} segments for table: {table_name}")
     
-    delete_url = f"http://{args.host}:{args.port}/segments/{table_name}_{table_type}"
-    params = {'type': table_type}
-    for segment in segments:
-        params['segments'] = segment
+    delete_url = f"http://{args.host}:{args.port}/segments/{table_name}"
+    params = {
+        'type': table_type,
+        'segments': segments
+    }
     
     if args.debug:
         print(f"    Delete URL: {delete_url}")
-        print(f"    Parameters: {params}")
+        print(f"    Query parameters: {json.dumps(params, indent=2)}")
     
-    response = make_request(delete_url, method='DELETE', params=params, timeout=30)
+    response = make_request(delete_url, method='DELETE', params=params, timeout=30, debug=args.debug)
     
     if args.debug:
         print(f"    Response status code: {response.status_code}")


### PR DESCRIPTION
Fixes the bug that was only deleting one segment out of all the detected. The API endpoint and the way we were providing the list of segments was incorrect as we were using the one for single segment delete.



### Test Run

```
(⎈|gke_mvp-demo-301906_us-west1-a_dev-gcp:kfuse-aishik-2) [⎇ :fixBatchDeleteBug] [work/customer/scripts] python3 deleteSegmentsByTableAndWhereClause.py --tables kf_metrics --where "KV_MATCHERS("labels", 'kf_node', '=', 'gke-demo-2-target-pool-spot-63e5ce7f-09hc', 'true') limit 1000"
/Users/aishik/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
  warnings.warn(
======================================================================
Apache Pinot Segment Cleanup Tool - Multi Table Version
======================================================================
Controller: localhost:9000
Broker: localhost:8099
Tables and their WHERE clauses:
  - kf_metrics: KV_MATCHERS(labels, 'kf_node', '=', 'gke-demo-2-target-pool-spot-63e5ce7f-09hc', 'true') limit 1000
Mode: LIVE (will delete matching segments)
======================================================================
Successfully connected to Pinot services
======================================================================
Validating table names...
All 1 specified tables exist in Pinot.
======================================================================

Processing table: kf_metrics
  Found table in formats: REALTIME
  Executing query: SELECT DISTINCT $segmentName FROM "kf_metrics" WHERE KV_MATCHERS(labels, 'kf_node', '=', 'gke-demo-2-target-pool-spot-63e5ce7f-09hc', 'true') limit 1000
  Query executed successfully.
  Found 12 segments:
    - kf_metrics__0__147__20250430T1854Z
    - kf_metrics__0__148__20250430T1959Z
    - kf_metrics__0__149__20250430T2103Z
    - kf_metrics__0__150__20250430T2156Z
    - kf_metrics__0__153__20250501T0035Z
    ... and 7 more segments
  Are you sure you want to delete these 12 segments from kf_metrics? (y/n): y

  Processing REALTIME segments for table: kf_metrics
    Successfully deleted 12 segments from kf_metrics (REALTIME)

======================================================================
Summary:
Table: kf_metrics
  Segments deleted: 12
  Segments failed to delete: 0
----------------------------------------------------------------------
Total segments deleted: 12
Total segments failed to delete: 0
```

### Checking for Deleted Segments in the Table
<img width="1502" alt="image" src="https://github.com/user-attachments/assets/d3d40373-e5c1-4699-9b21-89b1e0091d48" />
<img width="1502" alt="image" src="https://github.com/user-attachments/assets/643dfba2-f494-4872-b423-46729ba1cccc" />
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/bfb70444-b065-4029-b610-f500288b0894" />
