### PR TITLE
Update Kafka replication scripts to handle different broker ID patterns

### DIFF
--- a/scripts/initproducer-id-errors/CHANGE_RF.md
+++ b/scripts/initproducer-id-errors/CHANGE_RF.md
@@ -4,8 +4,13 @@
   - kubectl exec -it kafka-broker-0 bash
   - unset JMX_PORT
   - cd /opt/bitnami/kafka/bin/
+  - First, check your broker IDs using one of these methods:
+    - ./kafka-metadata-shell.sh --snapshot /bitnami/kafka/data/__cluster_metadata-0/00000000000000000000.log --print-brokers 2>/dev/null | grep "BrokerId:" | awk '{print $2}'
+    - Or if the above doesn't work: ./kafka-broker-api-versions.sh --bootstrap-server localhost:9092 | grep -E "id [0-9]+" | awk '{print $2}' | sort -n | uniq
   - ./kafka-reassign-partitions.sh --bootstrap-server localhost:9092 --topics-to-move-json-file /tmp/topics.json --broker-list <broker_list> --generate > /tmp/proposal.json
-  - Here <broker_list> should be 100,101...100+num_brokers-1. Eg: if there are 7 brokers then pass 100,101,102,103,104,105,106
+  - Here <broker_list> should be the comma-separated list of broker IDs from the previous command. Examples:
+    - If broker IDs are 0,1,2 then pass: 0,1,2
+    - If broker IDs are 100,101,102,103,104,105,106 then pass: 100,101,102,103,104,105,106
 3. Copy proposal.json out of kafka broker pod
    - kubectl cp kafka-broker-0:/tmp/proposal.json /tmp/proposal.json
 4. Run script to create new assignment plan

--- a/scripts/initproducer-id-errors/kafka_replication_increase.py
+++ b/scripts/initproducer-id-errors/kafka_replication_increase.py
@@ -7,13 +7,24 @@ Given a set of replicas - current_replicas, and desired replication_factor - rf,
 adds needed number of replicas for every patition in a topic.
 - keeps current replicas as is (no data movement)
 - ensures new replica is not a duplicate
+- automatically detects broker ID pattern (starting from 0 or 100)
 Eg:
 current_replicas = [100, 102], desired_rf = 3, num_brokers = 7, new_replicas = [103] so output will be [100, 102, 103]
-current_replicas = [100, 106], desired_rf = 3, num_brokers = 7, new_replicas = [101] so output will be [100, 106, 101]
+current_replicas = [0, 2], desired_rf = 3, num_brokers = 3, new_replicas = [1] so output will be [0, 2, 1]
 """
 def reassign(args):
     topic_metadata = get_proposal(args.proposal_file)
     print(f"Current topic info: {topic_metadata}")
+    
+    # Detect broker ID pattern by examining all current replicas
+    all_replicas = []
+    for partition in topic_metadata['partitions']:
+        all_replicas.extend(partition['replicas'])
+    
+    min_broker_id = min(all_replicas)
+    broker_id_base = 100 if min_broker_id >= 100 else 0
+    print(f"Detected broker ID pattern: starting from {broker_id_base}")
+    
     reassignment_json = {
         "version": 1,
         "partitions": []
@@ -22,10 +33,13 @@ def reassign(args):
         current_replicas = [replica for replica in partition['replicas']]
         num_replicas = len(current_replicas)
         last_replica = max(current_replicas)
-        # kafka replica ids start with 100
+        # kafka replica ids may start with 0 or 100 depending on deployment
         new_replicas = []
         while len(new_replicas) < (args.rf - len(current_replicas)):
-            last_replica = 100 + ((last_replica - 100 + 1) % args.num_brokers) # find next replica to assign
+            if broker_id_base == 100:
+                last_replica = 100 + ((last_replica - 100 + 1) % args.num_brokers)
+            else:
+                last_replica = (last_replica + 1) % args.num_brokers
             if last_replica in current_replicas: # newly found replica may already be in current set
                 continue
             # print(f"State: {len(new_replicas)}, last: {prev}, need: {args.rf - len(current_replicas)}, added: {last_replica}")
@@ -52,11 +66,11 @@ def get_proposal(proposal_file):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Process some personal information.")
-    parser.add_argument('--num_brokers', type=int, required=True)
-    parser.add_argument('--proposal_file', type=str, required=True)
-    parser.add_argument('--rf', type=int, required=True)
-    parser.add_argument('--output', type=str, default="reassignment.json", required=False)
+    parser = argparse.ArgumentParser(description="Increase Kafka topic replication factor. Automatically detects broker ID pattern (0-based or 100-based).")
+    parser.add_argument('--num_brokers', type=int, required=True, help='Total number of Kafka brokers')
+    parser.add_argument('--proposal_file', type=str, required=True, help='Path to proposal.json from kafka-reassign-partitions.sh')
+    parser.add_argument('--rf', type=int, required=True, help='Desired replication factor')
+    parser.add_argument('--output', type=str, default="reassignment.json", required=False, help='Output reassignment file path')
     args = parser.parse_args()
     reassign(args)
 


### PR DESCRIPTION
## Summary
- Updated CHANGE_RF.md runbook to include broker ID detection step
- Modified kafka_replication_increase.py to automatically detect broker ID pattern
- Script now works with both 0-based (Bitnami) and 100-based (standard) broker IDs

## Changes
1. **CHANGE_RF.md**: Added step to check broker IDs before running reassignment
2. **kafka_replication_increase.py**: 
   - Automatic detection of broker ID pattern by examining existing replicas
   - Works seamlessly with both ID patterns without manual configuration
   - Improved help text and documentation

## Test plan
- [x] Tested on iris cluster with Bitnami Kafka (0-based broker IDs)
- [ ] Test on a cluster with 100-based broker IDs

🤖 Generated with [Claude Code](https://claude.ai/code)