### PR TITLE
Update scaling runbooks for Kafka KRaft

### DIFF
--- a/runbooks/AGENTS.md
+++ b/runbooks/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance for AI agents working in this repository.
 
 ## Repository Purpose
 
-This repository contains operational runbooks and scripts for managing and troubleshooting the Kloudfuse observability stack. The stack runs on Kubernetes and includes Apache Pinot, Kafka, ZooKeeper, PostgreSQL, Grafana, and the Kloudfuse agents.
+This repository contains operational runbooks and scripts for managing and troubleshooting the Kloudfuse observability stack. The stack runs on Kubernetes and includes Apache Pinot, Kafka (KRaft mode — `kafka-kraft-broker` + `kafka-kraft-controller`, no Kafka ZooKeeper), ZooKeeper (used by Pinot only, as `pinot-zookeeper`), PostgreSQL, Grafana, and the Kloudfuse agents.
 
 **GitHub:** https://github.com/kloudfuse/customer
 

--- a/runbooks/Scale Up.md
+++ b/runbooks/Scale Up.md
@@ -26,7 +26,8 @@ To update the instance type (with higher resources) follow the steps below:
         * traces - increase the partitions of the kf_traces, kf_traces_errors and kf_traces_metrics
         * metrics - increase the partitions of the kf_metrics and kf_metrics_rollup
         * for some services such as, logs-parser, etc. number of replicas should be increased as well.
-     * increasing the memory / heap sizes for various services such as, pinot server realtime, ingester, etc. For components such as, logs-parser whose replica count is increased, memory increase may not be necessary.
+        * when increasing partitions, size the kafka-kraft broker disk accordingly using `diskSpace = numberOfPartitions * replicationFactor * 10GB` (default per-partition retention is 10GB via `kafka.logRetentionBytes`); update `kafka-kraft.broker.persistence.size` to match. After the partitions are increased, run a [kafka rebalance](kafka-rebalance.md) so the new partitions are evenly distributed across brokers.
+     * increasing the memory / heap sizes for various services such as, pinot server realtime, ingester, kafka-kraft broker (`kafka-kraft.broker.heapOpts`), etc. For components such as, logs-parser whose replica count is increased, memory increase may not be necessary.
     * Get the customer value yaml file reviewed by the CS as well as engineering team. This file can be kept ready and reviewed in anticipation of expected volume increase.
 ### Execution      
 - [ ] Increase the capacity of the AWS or GCP node pool by changing the instance type (or creating a new node pool with higher instance type and deleting old node pool). The kloudfuse installation requires all nodes to be of the same type and using the same set of taints and labels.

--- a/runbooks/ScaleOut.md
+++ b/runbooks/ScaleOut.md
@@ -22,10 +22,14 @@ To add additional nodes follow the steps below:
 - [ ] Review and validate if the existing customer values yaml file is correctly configured and up-to-date wrt actual kloudfuse installation. This is important if are changes made directly on the kloudfuse cluster that are not reflected in the customer values yaml. For example, if PVC is resized on the kloudfuse cluster, values yaml file might not have been updated.
 - [ ] Adjust the customer values yaml file by:
     * increasing the replica for each of the services by the right amount.
-        * for zookeeper (kafka zookeeper and pinot zookeeper) keep the number of replicas to 3.
+        * Kafka runs in KRaft mode (there is no Kafka ZooKeeper). It is deployed as two StatefulSets:
+            * `kafka-kraft-controller` - keep at 3 replicas. These hold the KRaft metadata quorum (odd replica count) and must not be scaled out with the cluster.
+            * `kafka-kraft-broker` - scale these out with the cluster to add ingest and storage capacity.
+        * for `pinot-zookeeper` keep the number of replicas to 3. This is the only remaining ZooKeeper (used by Pinot) and must not be scaled.
         * for some services such as, kfuse-redis, kfuse-configdb, kfuse-grafana, etc. keep the number of replicas at 1 as these services do not need to be scaled.
         * for all other services increase the number of replicas by appropriate ratio. So, if there were n nodes and m new nodes are being added, the replicas should be scaled up `(n + m) / n` factor.
     * Increase the number of partitions based on the increased volume as well as expected increase in the volume. Each of the streams such as, logs, metrics, APM have their specific topics for ingest, tranformers as well as for pinot. They all need to be increased in the right proportion.
+        * When increasing partitions, size the kafka-kraft broker disk accordingly using `diskSpace = numberOfPartitions * replicationFactor * 10GB` (the default per-partition retention is 10GB, set by `kafka.logRetentionBytes`). Set `kafka-kraft.broker.persistence.size` in the customer values yaml to match.
     * Get the customer value yaml file reviewed by the CS as well as engineering team.
     
 ### Execution      

--- a/runbooks/ScaleOut.md
+++ b/runbooks/ScaleOut.md
@@ -61,3 +61,74 @@ To add additional nodes follow the steps below:
 7. Individual stream specific control plane dashboards are all GREEN
 8. Kloudfuse UI does not show any lag and recent data is visible
 9. Verify that alert rules configured by the customer on the kloudfuse cluster are in “Healthy” state.
+
+## Troubleshooting
+
+### Newly added broker fails with `INCONSISTENT_CLUSTER_ID` (errorCode 104)
+
+**Symptom:** After scaling out from `N` to `N+1` (or more) brokers, the newly added `kafka-kraft-broker-<N>` pod(s) never become ready, and their logs show repeated errors fetching from every controller. In the example below, the new broker is `kafka-kraft-broker-3` (raft `id=103`), but this applies to whichever broker ordinal(s) were just added:
+
+```
+kubectl logs -n kfuse kafka-kraft-broker-<N>
+...
+ERROR [RaftManager id=10<N>] Unexpected error INCONSISTENT_CLUSTER_ID in FETCH response: InboundResponse(correlationId=..., data=FetchResponseData(..., errorCode=104, ...), source=kafka-kraft-controller-0.kafka-kraft-controller-headless.kfuse.svc.cluster.local:9093 ...) (org.apache.kafka.raft.KafkaRaftClient)
+```
+
+**Cause:** Each broker reads the KRaft cluster id **once** from the `kafka-kraft-kraft-cluster-id` secret on first startup, then persists it to its own `/bitnami/kafka/data/meta.properties` and never reads the secret again. A newly added broker reads whatever value the secret currently holds. If the secret is missing or no longer matches the rest of the cluster, the new broker writes a cluster id that does not match the controllers, and KRaft rejects all of its FETCH requests with `INCONSISTENT_CLUSTER_ID` (errorCode 104).
+
+Helm only **creates** the `kafka-kraft-kraft-cluster-id` secret if it does not already exist (it never overwrites it). So if someone deleted the secret, the next helm upgrade regenerated it with a **new, random** cluster id — which then mismatches the existing controllers and brokers that still carry the original id. This is the usual root cause.
+
+> ⚠️ The cluster id you pin **must** equal the id the existing controllers already use. Pinning a different value, or letting helm regenerate a random one, will break the entire Kafka cluster, not just the new broker(s).
+
+**Resolution:**
+
+1. Read the actual cluster id from a healthy controller (this is the source of truth — the controllers hold the real id in their persisted `meta.properties`):
+
+   ```bash
+   kubectl exec -n kfuse kafka-kraft-controller-0 -- grep cluster.id /bitnami/kafka/data/meta.properties
+   ```
+
+   Optionally cross-check it against the current secret value:
+
+   ```bash
+   kubectl get secret -n kfuse kafka-kraft-kraft-cluster-id -o jsonpath='{.data.*}' | base64 -d
+   ```
+
+2. Pin that exact cluster id in the customer values yaml under the `kafka-kraft` section:
+
+   ```yaml
+   kafka-kraft:
+     kraft:
+       clusterId: "<value from step 1>"
+   ```
+
+3. Run `helm upgrade` using the **same version as currently installed** (pinning `clusterId` makes helm reconcile the secret to the correct value):
+
+   ```bash
+   helm upgrade <release> <chart> -n kfuse -f <customer-values.yaml> --version <installed-version>
+   ```
+
+4. For **each** newly added broker that logged `INCONSISTENT_CLUSTER_ID`, delete its PVC and pod so it re-initializes its `meta.properties` from the now-correct secret (the StatefulSet recreates the pod automatically). Replace `<N>` with the affected broker ordinal:
+
+   ```bash
+   N=<broker-ordinal>   # e.g. 3, or repeat for each newly added broker
+   kubectl delete pvc -n kfuse "data-kafka-kraft-broker-${N}"
+   kubectl delete pod -n kfuse "kafka-kraft-broker-${N}"
+   ```
+
+5. Confirm each recreated pod reaches `Running` and the `INCONSISTENT_CLUSTER_ID` errors stop:
+
+   ```bash
+   kubectl get pods -n kfuse | grep kafka-kraft-broker
+   kubectl logs -n kfuse "kafka-kraft-broker-${N}" --tail=50
+   ```
+
+**Alternative (secret was deleted):** If you confirm the secret is missing or wrong, you can instead let helm recreate it from the pinned value — delete the secret **after** pinning `kraft.clusterId` in step 2 (never delete it without pinning, or helm will generate a fresh random id), then helm upgrade and delete the affected broker(s)' pvc/pod as in steps 4–5:
+
+```bash
+kubectl delete secret -n kfuse kafka-kraft-kraft-cluster-id
+helm upgrade <release> <chart> -n kfuse -f <customer-values.yaml> --version <installed-version>
+N=<broker-ordinal>
+kubectl delete pvc -n kfuse "data-kafka-kraft-broker-${N}"
+kubectl delete pod -n kfuse "kafka-kraft-broker-${N}"
+```

--- a/runbooks/custom-retention-partition-increase.md
+++ b/runbooks/custom-retention-partition-increase.md
@@ -23,3 +23,15 @@ This change applies to the following topics:
 - `kf_traces_topic`
 - `kf_traces_errors_topic`
 - `kf_events_topic`
+
+### Size the Kafka broker disk for the added partitions
+
+Adding partitions for a custom retention class increases the total disk required on the kafka-kraft brokers. Size the broker disk using:
+
+> `diskSpace = numberOfPartitions * replicationFactor * 10GB`
+
+where 10GB is the default per-partition retention (`kafka.logRetentionBytes`). Update `kafka-kraft.broker.persistence.size` in the customer values yaml to match the new partition count before applying the change.
+
+### Rebalance after increasing partitions
+
+After the partition count is increased, run a [kafka rebalance](kafka-rebalance.md) so the new partitions are evenly distributed across all brokers.

--- a/runbooks/kafka-rebalance.md
+++ b/runbooks/kafka-rebalance.md
@@ -83,12 +83,12 @@ cat > /bitnami/kafka/topics.json
     { "topic": "kf_events_topic" },
     { "topic": "kf_logs_metric_topic" },
     { "topic": "kf_logs_topic" },
-    { "topic": "logs_ingest_topic" }
+    { "topic": "logs_ingest_topic" },
     { "topic": "kf_metrics_topic" },
     { "topic": "kf_metrics_rollup_topic" },
     { "topic": "kf_traces_errors_topic" },
     { "topic": "kf_traces_metric_topic" },
-    { "topic": "kf_traces_topic" },
+    { "topic": "kf_traces_topic" }
   ]
 }
 ```
@@ -192,4 +192,4 @@ Re-run the above command to check the status of reassignment. This will provide 
 
 ## 🧠 Wrapping Up
 
-Adding Kafka brokers is just step one. Without rebalancing, you won’t get the performance boost or reliability benefits of a bigger cluster. Use the steps above to do it right and ensure your cluster is balanced and efficient.:1
+Adding Kafka brokers is just step one. Without rebalancing, you won’t get the performance boost or reliability benefits of a bigger cluster. Use the steps above to do it right and ensure your cluster is balanced and efficient.


### PR DESCRIPTION
## Summary

`ScaleOut.md` and `Scale Up.md` still described the legacy ZooKeeper-based Kafka topology. Kafka now runs in **KRaft mode** (`kafka-kraft-broker` + `kafka-kraft-controller`, no Kafka ZooKeeper); `pinot-zookeeper` is the only remaining ZooKeeper. This PR brings the scaling/partition runbooks (and the `AGENTS.md` stack description) in line with the current architecture, adds a KRaft scale-out troubleshooting section, and fixes a couple of long-standing nits in `kafka-rebalance.md`.

## Changes

- **`ScaleOut.md`**
  - Replace the incorrect *"for zookeeper (kafka zookeeper and pinot zookeeper) keep the number of replicas to 3"* guidance with the KRaft broker/controller split: `kafka-kraft-controller` stays at 3 (metadata quorum, not scaled), `kafka-kraft-broker` scales out, `pinot-zookeeper` stays at 3. Added broker disk-sizing formula for partition increases.
  - New **Troubleshooting** section for `INCONSISTENT_CLUSTER_ID` (errorCode 104) on a newly added broker: root cause (stale/regenerated `kafka-kraft-kraft-cluster-id` secret) and the fix — read the real cluster id from a controller, pin `kafka-kraft.kraft.clusterId`, helm upgrade, then delete the affected broker's pvc+pod. Broker ordinal is parameterized so it applies to any scale-out.
- **`Scale Up.md`** — name the kafka-kraft broker heap knob (`kafka-kraft.broker.heapOpts`) and add the disk-sizing formula + a pointer to the kafka rebalance runbook.
- **`AGENTS.md`** — clarify the stack runs Kafka in KRaft mode and that ZooKeeper is now Pinot-only.
- **`custom-retention-partition-increase.md`** — add the kafka-kraft broker disk-sizing formula and a pointer to the kafka rebalance runbook (adding partitions for a retention class increases broker disk need and requires a rebalance).
- **`kafka-rebalance.md`** — fix the malformed `topics.json` example (missing comma after `logs_ingest_topic`, trailing comma after `kf_traces_topic`) so it is valid JSON; remove the stray `:1` at EOF.

Values and the `diskSpace = numberOfPartitions * replicationFactor * 10GB` formula are referenced from [docs.kloudfuse.com/platform/latest](https://docs.kloudfuse.com/platform/latest/).